### PR TITLE
Pipe fontification

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -102,7 +102,7 @@ The line containing RE is matched, as well as all lines indented beneath it."
     (haml-highlight-ruby-tag              1 font-lock-preprocessor-face)
     (haml-highlight-ruby-script           1 font-lock-preprocessor-face)
     ("^!!!.*"                             0 font-lock-constant-face)
-    ("| *$"                               0 font-lock-string-face)))
+    ("\\s| *$"                               0 font-lock-string-face)))
 
 (defconst haml-filter-re "^[ \t]*:\\w+")
 (defconst haml-comment-re "^[ \t]*\\(?:-\\#\\|/\\)")


### PR DESCRIPTION
Hi,

I love haml and sass... thanks a lot!  Here's my oh-so-minor contribution.

Also, have you tried haml-mode in the development version of gnu emacs (i.e. 24.0.50.1)?  Fontification doesn't work.  Hopefully it is something emacs devs will sort out, but I thought I'd give you a heads up.

-Mark
