### PR TITLE
syntax-propertize-function compatibility (Emacs 24 support)

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -107,7 +107,7 @@ The line containing RE is matched, as well as all lines indented beneath it."
 (defconst haml-filter-re "^[ \t]*:\\w+")
 (defconst haml-comment-re "^[ \t]*\\(?:-\\#\\|/\\)")
 
-(defun haml-fontify-region (beg end keywords syntax-table syntactic-keywords)
+(defun haml-fontify-region (beg end keywords syntax-table syntactic-keywords-or-propertize-function)
   "Fontify a region between BEG and END using another mode's fontification.
 
 KEYWORDS, SYNTAX-TABLE, and SYNTACTIC-KEYWORDS are the values of that mode's
@@ -117,7 +117,10 @@ and `font-lock-syntactic-keywords', respectively."
     (save-match-data
       (let ((font-lock-keywords keywords)
             (font-lock-syntax-table syntax-table)
-            (font-lock-syntactic-keywords syntactic-keywords)
+            (font-lock-syntactic-keywords (unless (functionp syntactic-keywords-or-propertize-function)
+                                              syntactic-keywords-or-propertize-function))
+            (syntax-propertize-function (when (functionp syntactic-keywords-or-propertize-function)
+                                          syntactic-keywords-or-propertize-function))
             (font-lock-multiline 'undecided)
             font-lock-keywords-only
             font-lock-extend-region-functions
@@ -130,7 +133,9 @@ and `font-lock-syntactic-keywords', respectively."
   "Use Ruby's font-lock variables to fontify the region between BEG and END."
   (haml-fontify-region beg end ruby-font-lock-keywords
                        ruby-font-lock-syntax-table
-                       ruby-font-lock-syntactic-keywords))
+                       (if (boundp 'ruby-font-lock-syntactic-keywords)
+                           ruby-font-lock-syntactic-keywords
+                          'ruby-syntax-propertize-function)))
 
 (defun haml-handle-filter (filter-name limit fn)
   "If a FILTER-NAME filter is found within LIMIT, run FN on that filter.


### PR DESCRIPTION
When ruby-font-lock-syntactic-keywords is not bound, use ruby-syntax-propertize-function for Emacs 24 compatibility.

This is a simple fix that uses the new syntax-propertize-function for font-lock, since the syntactic-keywords stuff is deprecated and appears to be completely gone in ruby-mode in Emacs 24.
