### PR TITLE
haml-electric-backspace falls back to backward-delete-char at end of buff

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -721,6 +721,7 @@ the current line."
   (interactive "*p")
   (if (or (/= (current-indentation) (current-column))
           (bolp)
+          (eobp)
           (looking-at "^[ \t]+$"))
       (backward-delete-char arg)
     (save-excursion


### PR DESCRIPTION
haml-electric-backspace falls back to backward-delete-char at end of buffer

Fixes issue #5
