### PR TITLE
Fixed the end of string in `auto-mode-alist` regexp.

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -746,7 +746,7 @@ the current line."
   (mapconcat 'identity (make-list haml-indent-offset " ") ""))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.haml$" . haml-mode))
+(add-to-list 'auto-mode-alist '("\\.haml\\'" . haml-mode))
 
 ;; Setup/Activation
 (provide 'haml-mode)


### PR DESCRIPTION
`$` could match a newline whereas `\\'` cannot.
