### PR TITLE
Fixes for recent ruby-mode.el and js.el compatibility

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -137,8 +137,8 @@ respectively."
                        ruby-font-lock-syntax-table
                        (when (boundp 'ruby-font-lock-syntactic-keywords)
                          ruby-font-lock-syntactic-keywords)
-                       (when (boundp 'ruby-syntax-propertize-function)
-                         ruby-syntax-propertize-function)))
+                       (when (fboundp 'ruby-syntax-propertize-function)
+                         #'ruby-syntax-propertize-function)))
 
 (defun haml-handle-filter (filter-name limit fn)
   "If a FILTER-NAME filter is found within LIMIT, run FN on that filter.


### PR DESCRIPTION
These commits make haml-mode work correctly with the ruby-mode.el shipped with recent Emacs versions, and resolve an issue with `javascript:` blocks which could break fontification for some or all of the current file.

Additionally, I've marked "ruby-mode" as a package dependency, for the sake of completeness.

-Steve
