### PR TITLE
Don't require a space before ruby code

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -237,7 +237,7 @@ END.")
   "Regexp to match trailing ruby code which may continue onto subsequent lines.")
 
 (defconst haml-ruby-script-re
-  (concat "^[ \t]*\\(-\\|[&!]?[=~]\\) " haml-possibly-multiline-code-re)
+  (concat "^[ \t]*\\(-\\|[&!]?[=~]\\)" haml-possibly-multiline-code-re)
   "Regexp to match -, = or ~ blocks and any continued code lines.")
 
 (defun haml-highlight-ruby-script (limit)


### PR DESCRIPTION
As far as I can tell this space is not a requirement of Haml nor does it
impair the workings of the Haml or Ruby code.
