### PR TITLE
"_" should not have word syntax.

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -467,7 +467,6 @@ changes in the initial region."
 (defvar haml-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?: "." table)
-    (modify-syntax-entry ?_ "w" table)
     (modify-syntax-entry ?' "\"" table)
     table)
   "Syntax table in use in `haml-mode' buffers.")


### PR DESCRIPTION
- This makes it harder to navigate for those of us familiar with symbol
  movements.
