### PR TITLE
Why does _ have word syntax?

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -467,7 +467,6 @@ changes in the initial region."
 (defvar haml-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?: "." table)
-    (modify-syntax-entry ?_ "w" table)
     (modify-syntax-entry ?' "\"" table)
     table)
   "Syntax table in use in `haml-mode' buffers.")


### PR DESCRIPTION
Hi,

I present this as a pull request, but really I'd like to know if there is any specific reason why `haml-mode` gives `_` word syntax. This is very confusing for me when I use `forward-word` and `delete-word`, etc.

I've looked through the git history and I see some people being thanked for updates, but I can't quite figure out a reason for this particular line of code.
