### PR TITLE
Remove support for obsolete javascript-mode

### DIFF
--- a/haml-mode.el
+++ b/haml-mode.el
@@ -30,10 +30,7 @@
 (require 'css-mode nil t)
 (require 'textile-mode nil t)
 (require 'markdown-mode nil t)
-(or
- (require 'js nil t)
- (require 'javascript-mode "javascript" t))
-
+(require 'js nil t)
 
 ;; User definable variables
 
@@ -170,15 +167,15 @@ This requires that `css-mode' is available.
 This requires that Karl Landström's javascript mode be available, either as the
 \"js.el\" bundled with Emacs >= 23, or as \"javascript.el\" found in ELPA and
 elsewhere."
-  (let ((keywords (or (and (featurep 'js) js--font-lock-keywords-3)
-                      (and (featurep 'javascript-mode) js-font-lock-keywords-3)))
-        (syntax-table (or (and (featurep 'js) js-mode-syntax-table)
-                          (and (featurep 'javascript-mode) javascript-mode-syntax-table)))
-        (syntax-propertize (and (featurep 'js) 'js-syntax-propertize)))
-    (when keywords
-      (when (and (fboundp 'js--update-quick-match-re) (null js--quick-match-re-func))
-        (js--update-quick-match-re))
-      (haml-fontify-region beg end keywords syntax-table nil syntax-propertize))))
+  (when js--font-lock-keywords-3
+    (when (and (fboundp 'js--update-quick-match-re)
+	       (null js--quick-match-re-func))
+      (js--update-quick-match-re))
+    (haml-fontify-region beg end
+			 js--font-lock-keywords-3
+			 js-mode-syntax-table
+			 nil
+			 'js-syntax-propertize)))
 
 (defun haml-fontify-region-as-textile (beg end)
   "Highlight textile from BEG to END.


### PR DESCRIPTION
Instead of supporting `js` as well as `javascript-mode`, only support
the former.  Actually these are both the same package; a long time ago
`js` used to be named `javascript-mode`.  Since version 23.2 `js` is
part of Emacs, so nowadays nobody should be using it under its old
name anymore.

Closes #34.